### PR TITLE
Add new client CVAR to enforce, v_vmtweak.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Weapon viewmodel will be visible as normal.
 
 #### Modified values  
 
-Custom values (1) can allow clients to make the viewmodel invisible or otherwise look different to normal, potentially providing a gameplay advantage.  
+Custom values (1) can allow clients to make the viewmodel invisible or otherwise look different to normal, potentially providing a gameplay advantage. It can also disable muzzle flash. 
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ This is how the shadow should look like, with its angle tied to the map's sun an
 
 Custom values will render an always front-facing, blob-shaped shadow, which can reveal enemies behind corners in ways that normally aren't possible.
 
-![r_shadowrendertotexture_0](https://user-images.githubusercontent.com/6595066/210471026-9ea1f4af-51c0-4e54-931e-7edbcde7f4f2.jpg)
+![r_shadowrendertotexture_0](https://user-images.githubusercontent.com/6595066/210471026-9ea1f4af-51c0-4e54-931e-7edbcde7f4f2.jpg)  
+
+### v_vmtweak
+
+#### Default value (0)  
+
+Weapon viewmodel will be visible as normal.  
+
+#### Modified values  
+
+Custom values (1) can allow clients to make the viewmodel invisible or otherwise look different to normal, potentially providing a gameplay advantage.  
 
 ## Building
 

--- a/addons/sourcemod/scripting/nt_comp_enforce_clientvals.sp
+++ b/addons/sourcemod/scripting/nt_comp_enforce_clientvals.sp
@@ -19,6 +19,7 @@ public Plugin myinfo = {
 // Names of the cvars, followed by the value that is enforced for them.
 char g_enforcedVals[][][] = {
     { "r_shadowrendertotexture", "1" },  // Player cvar to monitor, followed by the value it must hold.
+    { "v_vmtweak", "0" },
 };
 
 public void OnPluginStart()

--- a/addons/sourcemod/scripting/nt_comp_enforce_clientvals.sp
+++ b/addons/sourcemod/scripting/nt_comp_enforce_clientvals.sp
@@ -4,7 +4,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "0.2.0"
+#define PLUGIN_VERSION "0.2.1"
 
 char g_sPluginTag[] = "[COMP CVARS]";
 


### PR DESCRIPTION
The client CVAR `v_vmtweak` should be `0` (default), other values such as `1` can provide an advantage and even allow making the viewmodel invisible when used with the other modified viewmodel cvars (`v_vm...`). It can also be used to disable muzzle flash.